### PR TITLE
feature: Implemented final boss bullets

### DIFF
--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import entity.FinalBoss;
 import screen.Screen;
 import entity.Entity;
 import entity.Ship;
@@ -74,6 +75,10 @@ public final class DrawManager {
 		EnemyShipC2,
 		/** Bonus ship. */
 		EnemyShipSpecial,
+        /** Final boss - first form **/
+        FinalBoss,
+        /** Final boss - second form **/
+        FinalBoss2,
 		/** Destroyed enemy ship. */
 		Explosion
 	};
@@ -100,6 +105,11 @@ public final class DrawManager {
 			spriteMap.put(SpriteType.EnemyShipC1, new boolean[12][8]);
 			spriteMap.put(SpriteType.EnemyShipC2, new boolean[12][8]);
 			spriteMap.put(SpriteType.EnemyShipSpecial, new boolean[16][7]);
+
+            /** when final boss' spritetype is implemeted, need to add **/
+            //spriteMap.put(SpriteType.FinalBoss, new boolean[100][80]);
+            //spriteMap.put(SpriteType.FinalBoss2, new boolean[100][80]);
+
 			spriteMap.put(SpriteType.Explosion, new boolean[13][7]);
 
 			fileManager.loadSprite(spriteMap);
@@ -194,6 +204,17 @@ public final class DrawManager {
 				if (image[i][j])
 					backBufferGraphics.drawRect(positionX + i * 2, positionY
 							+ j * 2, 1, 1);
+
+        /** draw hitbox of final boss because final boss' spritetype is not implemented(for test) **/
+        if( entity instanceof FinalBoss){
+            backBufferGraphics.setColor(Color.RED);
+            backBufferGraphics.drawRect(
+                    entity.getPositionX(),
+                    entity.getPositionY(),
+                    entity.getWidth(),
+                    entity.getHeight()
+            );
+        }
 	}
 
 	/**

--- a/src/entity/BossBullet.java
+++ b/src/entity/BossBullet.java
@@ -1,0 +1,39 @@
+package entity;
+
+import engine.DrawManager;
+
+import java.awt.*;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BossBullet extends Entity{
+    private int dx;
+    private int dy;
+    private static Set<BossBullet> bossBullets = new HashSet<>();
+
+    public BossBullet(int x, int y, int dx, int dy, int width, int height) {
+        super(x, y, width, height, Color.YELLOW);
+        this.dx = dx;
+        this.dy = dy;
+        bossBullets.add(this);
+        this.spriteType = DrawManager.SpriteType.EnemyBullet;
+    }
+
+    public void update() {
+        this.positionX += this.dx;
+        this.positionY += this.dy;
+    }
+
+    public boolean isOffScreen(int screenWidth, int screenHeight) {
+        return positionX < 0 || positionX > screenWidth ||
+                positionY < 0 || positionY > screenHeight;
+    }
+
+    public boolean collidesWith(Entity other) { return this.getPositionX() < other.getPositionX() + other.getWidth() && this.getPositionX() + this.getWidth() > other.getPositionX() && this.getPositionY() < other.getPositionY() + other.getHeight() && this.getPositionY() + this.getHeight() > other.getPositionY(); }
+
+    public static Set<BossBullet> getBossBullets() {
+        return bossBullets;
+    }
+
+
+}

--- a/src/entity/FinalBoss.java
+++ b/src/entity/FinalBoss.java
@@ -1,0 +1,124 @@
+package entity;
+
+import engine.DrawManager;
+import engine.Cooldown;
+import engine.Core;
+import screen.GameScreen;
+
+import java.awt.*;
+
+public class FinalBoss extends Entity{
+
+    private int healPoint;
+    private int maxHp;
+    private final int pointValue;
+    private boolean isDestroyed;
+    /** for move pattern **/
+    private int zigDirection = 1;
+    /** for move pattern **/
+    private boolean goingDown = true;
+
+    private Cooldown animationCooldown;
+    private Cooldown shootCooldown;
+    private final GameScreen screen;
+    /** basic attribute of final boss **/
+    public FinalBoss(int positionX, int positionY, GameScreen screen){
+
+        super(positionX,positionY,100,80, Color.RED);
+        this.screen = screen;
+        this.healPoint = 20;
+        this.maxHp = healPoint;
+        this.pointValue = 1000;
+        this.spriteType = DrawManager.SpriteType.EnemyShipSpecial;
+        this.isDestroyed = false;
+
+        this.animationCooldown = Core.getCooldown(500);
+        this.shootCooldown = Core.getCooldown(1000);
+    }
+
+    /** for vibrant moving with final boss **/
+    /** final boss spritetype is the same with special enemy and enemyshipA, because final boss spritetype have not yet implemented **/
+    /** becasue final boss is single object, moving and shooting pattern are included in update methods **/
+    public void update(){
+        if(this.animationCooldown.checkFinished()){
+            this.animationCooldown.reset();
+
+            if(this.spriteType == DrawManager.SpriteType.EnemyShipSpecial){
+                this.spriteType = DrawManager.SpriteType.EnemyShipA1;
+            } else{
+                this.spriteType = DrawManager.SpriteType.EnemyShipSpecial;
+            }
+        }
+        movePattern();
+        shoot();
+    }
+
+    /** decrease boss' healpoint **/
+    public void takeDamage(int damage){
+        this.healPoint -= damage;
+        if(this.healPoint <= 0){
+            this.destroy();
+        }
+    }
+
+    public int getHealPoint(){
+        return this.healPoint;
+    }
+    public int getPointValue(){
+        return this.pointValue;
+    }
+
+    /** movement pattern of final boss **/
+    public void movePattern(){
+        if(this.healPoint > this.maxHp/2){
+            this.move(0,0);
+        }
+        else {
+            this.moveZigzag(3,2);
+        }
+    }
+
+    /** move zigzag **/
+    public void moveZigzag(int zigSpeed, int vertSpeed){
+        this.positionX += (this.zigDirection * zigSpeed);
+        if(this.positionX <= 0 || this.positionX >= screen.getWidth()-this.width){
+            this.zigDirection *= -1;
+        }
+
+        if(goingDown) {
+            this.positionY += vertSpeed;
+            if (this.positionY >= screen.getHeight()/2 - this.height) goingDown = false;
+        }
+        else {
+            this.positionY -= vertSpeed;
+            if(this.positionY <= 0) goingDown = true;
+        }
+    }
+
+    /** move simple **/
+    public void move(int distanceX, int distanceY){
+        this.positionX += distanceX;
+        this.positionY += distanceY;
+    }
+
+    /** not yet implemented **/
+    public void shoot(){
+        if(this.shootCooldown.checkFinished()){
+            this.shootCooldown.reset();
+            // 총알 객체 생성 로직
+        }
+    }
+
+    /** flag final boss' destroy **/
+    public void destroy(){
+        if(!this.isDestroyed){
+            this.isDestroyed = true;
+            this.spriteType = DrawManager.SpriteType.Explosion;
+        }
+    }
+
+    /** check final boss' destroy **/
+    public boolean isDestroyed(){
+        return this.isDestroyed;
+    }
+}

--- a/src/entity/FinalBoss.java
+++ b/src/entity/FinalBoss.java
@@ -19,7 +19,10 @@ public class FinalBoss extends Entity{
     private boolean goingDown = true;
 
     private Cooldown animationCooldown;
-    private Cooldown shootCooldown;
+    private Cooldown shootCooldown1;
+    private Cooldown shootCooldown2;
+    private Cooldown shootCooldown3;
+    private static int random_x;
     private final GameScreen screen;
     /** basic attribute of final boss **/
     public FinalBoss(int positionX, int positionY, GameScreen screen){
@@ -33,7 +36,9 @@ public class FinalBoss extends Entity{
         this.isDestroyed = false;
 
         this.animationCooldown = Core.getCooldown(500);
-        this.shootCooldown = Core.getCooldown(1000);
+        this.shootCooldown1 = Core.getCooldown(5000);
+        this.shootCooldown2 = Core.getCooldown(400);
+        this.shootCooldown3 = Core.getCooldown(100);
     }
 
     /** for vibrant moving with final boss **/
@@ -50,7 +55,8 @@ public class FinalBoss extends Entity{
             }
         }
         movePattern();
-        shoot();
+        shoot1();
+        shoot2();
     }
 
     /** decrease boss' healpoint **/
@@ -102,10 +108,32 @@ public class FinalBoss extends Entity{
     }
 
     /** not yet implemented **/
-    public void shoot(){
-        if(this.shootCooldown.checkFinished()){
-            this.shootCooldown.reset();
-            // 총알 객체 생성 로직
+    public void shoot1(){
+        if(this.shootCooldown1.checkFinished()){
+            this.shootCooldown1.reset();
+            // 총알 5방향 객체 생성 로직
+            int arr[] = {0,1,-1,2,-2};
+            for (int i : arr){
+                new BossBullet(this.getPositionX() + this.getWidth() / 2 - 3,this.getPositionY() + this.getHeight(), i,4,6,10);
+            }
+        }
+    }
+    public void shoot2() {
+        random_x = (int) (Math.random() * 450);
+        if (this.shootCooldown2.checkFinished()) {
+            this.shootCooldown2.reset();
+            // 총알 일직선 객체 생성 로직
+            new BossBullet(random_x, 1, 0, 2,6,10);
+//            new BossBullet(bullet_a, 450, 0, -4,6,10);
+
+        }
+    }
+    public void shoot3(int x, int y) {
+        if (this.shootCooldown3.checkFinished()) {
+            this.shootCooldown3.reset();
+            // 총알 일직선 객체 생성 로직
+            new BossBullet(1, 1, 0, 5,6,10);
+
         }
     }
 


### PR DESCRIPTION
### 🚩 What is this PR?
[Implemented Player vertical movement logic](feature: Implemented final boss bullets)

### 📢 Changes-Detail
ex)
- Implemented final boss object which can shoot 5 bullets
- Implemented field bullets
-  implemented to remove the bullet when it was outside the screen.
- When the bullet collided with the ship, the ship was destroyed and implemented to cut lives.

### 📃 Progress

 - [o] Completed: Implemented boss bullets
 - [o] Completed: field bullets

 - [ ] To do: Add the logic of a bullet
 - [ ] To do: etc…

### ⚙️ Additional Notes
Created a class called BossBullet. Fixed the shoot logic for FinalBoss. Modified it in Gamescreen to remove the bullet when it collided with the ship and when the bullet went out of the screen. The revised parts in the Gamescreen may conflict with other teams, so capture them and attach them.
<img width="1122" height="862" alt="image" src="https://github.com/user-attachments/assets/b991e561-9fc0-443c-8d58-13ed4de57551" />
<img width="1625" height="912" alt="image" src="https://github.com/user-attachments/assets/3e00b338-a838-4c06-9a88-55cf5eb241aa" />
<img width="1347" height="416" alt="image" src="https://github.com/user-attachments/assets/dc242b57-8893-4672-828e-c0182b33c7f1" />

